### PR TITLE
add bun test, formatcheck and typecheck workflows

### DIFF
--- a/.github/workflows/bun-formatcheck.yml
+++ b/.github/workflows/bun-formatcheck.yml
@@ -1,0 +1,26 @@
+# Created using @tscircuit/plop (npm install -g @tscircuit/plop)
+name: Format Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  format-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run format check
+        run: bun run format:check

--- a/.github/workflows/bun-test.yml
+++ b/.github/workflows/bun-test.yml
@@ -1,0 +1,31 @@
+# Created using @tscircuit/plop (npm install -g @tscircuit/plop)
+name: Bun Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    # Skip test for PRs that not chore: bump version
+    if: "${{ github.event_name != 'pull_request' || github.event.pull_request.title != 'chore: bump version' }}"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Run tests
+        run: bun test

--- a/.github/workflows/bun-typecheck.yml
+++ b/.github/workflows/bun-typecheck.yml
@@ -1,0 +1,26 @@
+# Created using @tscircuit/plop (npm install -g @tscircuit/plop)
+name: Type Check
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  type-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun i
+
+      - name: Run type check
+        run: bunx tsc --noEmit

--- a/lib/entities/topology/AdvancedFace.ts
+++ b/lib/entities/topology/AdvancedFace.ts
@@ -2,14 +2,14 @@ import { Entity } from "../../core/Entity"
 import type { ParseContext } from "../../core/ParseContext"
 import type { Ref } from "../../core/Ref"
 import { register } from "../../parse/registry"
-import type { Surface } from "../../types/topology"
+import type { AnyFaceBound, Surface } from "../../types/topology"
 import type { FaceOuterBound } from "./FaceOuterBound"
 
 export class AdvancedFace extends Entity {
   readonly type = "ADVANCED_FACE"
   constructor(
     public name: string,
-    public bounds: Ref<FaceOuterBound>[],
+    public bounds: Ref<AnyFaceBound>[],
     public surface: Ref<Surface>,
     public sameSense: boolean,
   ) {
@@ -21,7 +21,7 @@ export class AdvancedFace extends Entity {
       .replace(/^\(|\)$/g, "")
       .split(",")
       .filter(Boolean)
-      .map((tok) => ctx.parseRef<FaceOuterBound>(tok.trim()))
+      .map((tok) => ctx.parseRef<AnyFaceBound>(tok.trim()))
     const surf = ctx.parseRef<Surface>(a[2])
     const ss = a[3].trim() === ".T."
     return new AdvancedFace(name, bounds, surf, ss)

--- a/lib/types/topology.d.ts
+++ b/lib/types/topology.d.ts
@@ -1,5 +1,8 @@
+import type { FaceBound } from "../entities/topology/FaceBound"
+import type { FaceOuterBound } from "../entities/topology/FaceOuterBound"
 import type { Plane } from "../entities/geometry/Plane"
 import type { CylindricalSurface } from "../entities/geometry/CylindricalSurface"
 import type { ToroidalSurface } from "../entities/geometry/ToroidalSurface"
 
+export type AnyFaceBound = FaceBound | FaceOuterBound
 export type Surface = Plane | CylindricalSurface | ToroidalSurface

--- a/tests/fixtures/step-snapshot.ts
+++ b/tests/fixtures/step-snapshot.ts
@@ -232,7 +232,6 @@ async function toMatchStepSnapshot(
 ) {
   const png = await renderStepToPNG(stepContent)
   // Delegate to existing PNG matcher for snapshot compare/update UX
-  // @ts-expect-error - custom matcher registered globally
   return await expect(png).toMatchPngSnapshot(testPathOriginal, pngName)
 }
 


### PR DESCRIPTION
+ fix type errors

 • Introducing a new AnyFaceBound union type that includes both FaceBound and FaceOuterBound.                                             
 • Updating the AdvancedFace entity to use the AnyFaceBound type for its bounds, allowing it to correctly handle both outer boundaries and inner holes.                                                                                                                           
 • Removing an unused @ts-expect-error directive in tests/fixtures/step-snapshot.ts.                                                      