### PR TITLE
fix: publish only dist and define stepts root exports explicitly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,18 @@
 {
   "name": "stepts",
-  "module": "lib/index.ts",
-  "main": "dist/index.js",
+  "module": "./dist/index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "version": "0.0.2",
   "repository": "https://github.com/tscircuit/stepts",
   "type": "module",


### PR DESCRIPTION

  Motivation:
  Downstream browser/CDN consumers were resolving stepts in a way that exposed internal lib/... paths, which made root
  imports fragile and contributed to deep subpath resolution such as lib/core/EntityId. That internal path is not a stable
  published API surface and was causing downstream browser import failures.

  Fix:

  - point main and module to ./dist/index.js
  - add types for the built declaration entrypoint
  - add an explicit root exports map for "."
  - publish only dist so the package consistently exposes the built artifact used by consumers

  This makes the public package contract explicit and ensures import { ... } from "stepts" resolves through the built root
  entrypoint rather than the internal source layout.